### PR TITLE
Windows/VSCode向けにDevContainerを利用した開発環境の追加

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,34 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.155.1/containers/typescript-node
+{
+	"name": "shokuen-frontend",
+	"build": {
+		"dockerfile": "../Dockerfile",
+	},
+
+	// Set *default* container specific settings.json values on container create.
+	"settings": { 
+		"terminal.integrated.shell.linux": "/bin/bash"
+	},
+
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"dbaeumer.vscode-eslint",
+		"esbenp.prettier-vscode",
+		"eamodio.gitlens"
+	],
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": "npm ci",
+
+	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	// "remoteUser": "node",
+
+	// Cache node_modules.
+	"mounts": [
+		"source=shokuen-frontend-node_modules,target=${containerWorkspaceFolder}/node_modules,type=volume"
+	]
+}

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -18,6 +18,14 @@ module.exports = {
         use: ['style-loader', 'css-loader']
       }
     ];
+    config.devServer = {
+      ...config.devServer,
+      watchOptions: {
+        poll: true,
+        ignored: /node_modules/
+      }
+    };
+    console.log(config);
     return config;
   }
 };

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM node:14.15.4-buster
+
+RUN apt-get update -y && \
+    apt-get install -y \
+        git \
+        vim && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  webpackDevMiddleware: (config) => {
+    // eslint-disable-next-line no-param-reassign
+    config.watchOptions = {
+      poll: true,
+      ignored: /node_modules/
+    };
+    return config;
+  }
+};


### PR DESCRIPTION
Windowsでファイル共有する場合にファイルシステムの違いからinotifyが機能しないため、webpackのwatchOptionsの設定でpollingしています。